### PR TITLE
fix: add PortalAccess to DictionaryController and add phone number prefixes seed data

### DIFF
--- a/packages/flowFlex-backend/WebApi/Controllers/Shared/DictionaryController.cs
+++ b/packages/flowFlex-backend/WebApi/Controllers/Shared/DictionaryController.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FlowFlex.Application.Contracts.Dtos.Shared;
+using FlowFlex.Application.Filter;
 using FlowFlex.Domain.Repository.Shared;
 using Item.Internal.StandardApi.Response;
 using Microsoft.AspNetCore.Authorization;
@@ -14,6 +15,7 @@ namespace FlowFlex.WebApi.Controllers.Shared;
 [Route("shared/v{version:apiVersion}/dictionary")]
 [Asp.Versioning.ApiVersion("1.0")]
 [Authorize]
+[PortalAccess]
 public class DictionaryController : Controllers.ControllerBase
 {
     private readonly IPhoneNumberPrefixRepository _phoneNumberPrefixRepository;


### PR DESCRIPTION
- Add [PortalAccess] attribute to DictionaryController to allow Portal token access
- Add seed SQL script with 247 country/region phone number prefixes from Dev environment
- Fixes: Portal phone prefix dropdown returning 403, Staging/Prod dropdown empty due to missing dat