### PR TITLE
fix: refresh entity after condition action to prevent GoToStage being…

### DIFF
--- a/packages/flowFlex-backend/Application/Services/OW/OnboardingServices/OnboardingStageManagementService.cs
+++ b/packages/flowFlex-backend/Application/Services/OW/OnboardingServices/OnboardingStageManagementService.cs
@@ -323,6 +323,19 @@ namespace FlowFlex.Application.Services.OW.OnboardingServices
 
             // === Condition actions succeeded (or no conditions) — now mark stage as completed ===
 
+            // If condition actions were executed (e.g. GoToStage), the action may have updated
+            // CurrentStageId/CurrentStageOrder directly in DB. We must refresh entity to avoid
+            // SaveOnboardingChangesAsync overwriting those changes with stale values.
+            if (conditionActionExecuted)
+            {
+                var refreshed = await _onboardingRepository.GetByIdAsync(id);
+                if (refreshed != null)
+                {
+                    entity.CurrentStageId = refreshed.CurrentStageId;
+                    entity.CurrentStageOrder = refreshed.CurrentStageOrder;
+                }
+            }
+
             // Update stages progress
             await _stageProgressService.UpdateStagesProgressAsync(entity, stageToComplete.Id, GetCurrentUserName(), GetCurrentUserId(), input.CompletionNotes);
 


### PR DESCRIPTION
When EvaluateAndExecuteStageConditionAsync executes a GoToStage action,
it updates CurrentStageId directly in DB via SQL UPDATE. However,
SaveOnboardingChangesAsync subsequently overwrites it with the stale
in-memory entity value, causing the case to advance to the wrong stage.

Refresh CurrentStageId/CurrentStageOrder from DB after condition actions
execute so the final save preserves the correct target stage.

Introduced by fad8a167, affects GoToStage / SkipStage / EndWorkflow actions.