### PR TITLE
The root cause was that Condition Actions updated onboarding data dir…

### DIFF
--- a/packages/flowFlex-backend/Application/Services/OW/OnboardingServices/OnboardingStageManagementService.cs
+++ b/packages/flowFlex-backend/Application/Services/OW/OnboardingServices/OnboardingStageManagementService.cs
@@ -323,9 +323,9 @@ namespace FlowFlex.Application.Services.OW.OnboardingServices
 
             // === Condition actions succeeded (or no conditions) — now mark stage as completed ===
 
-            // If condition actions were executed (e.g. GoToStage), the action may have updated
-            // CurrentStageId/CurrentStageOrder directly in DB. We must refresh entity to avoid
-            // SaveOnboardingChangesAsync overwriting those changes with stale values.
+            // If condition actions were executed (e.g. GoToStage/SkipStage), the action may have
+            // updated current stage and stages progress directly in DB. Refresh those fields before
+            // the normal completion flow serializes progress again.
             if (conditionActionExecuted)
             {
                 var refreshed = await _onboardingRepository.GetByIdAsync(id);
@@ -333,6 +333,17 @@ namespace FlowFlex.Application.Services.OW.OnboardingServices
                 {
                     entity.CurrentStageId = refreshed.CurrentStageId;
                     entity.CurrentStageOrder = refreshed.CurrentStageOrder;
+                    entity.CurrentStageStartTime = refreshed.CurrentStageStartTime;
+                    entity.Status = refreshed.Status;
+                    entity.ActualCompletionDate = refreshed.ActualCompletionDate;
+                    entity.CompletionRate = Math.Max(entity.CompletionRate, refreshed.CompletionRate);
+                    entity.Notes = refreshed.Notes;
+
+                    if (!string.IsNullOrWhiteSpace(refreshed.StagesProgressJson))
+                    {
+                        entity.StagesProgressJson = refreshed.StagesProgressJson;
+                        _stageProgressService.LoadStagesProgressFromJson(entity);
+                    }
                 }
             }
 


### PR DESCRIPTION
…ectly in the database. For example, GoToStage/SkipStage updated CurrentStageId/CurrentStageOrder and StagesProgressJson, marking intermediate stages as Skipped.

However, after the action ran, CompleteCurrentStageAsync continued using the stale in-memory entity.StagesProgress object to complete the current stage and save StagesProgressJson again. Since that in-memory object did not reload the skipped state that the action had just written to the database, the correct Skipped status was overwritten by the old progress snapshot. As a result, the frontend could not show the skipped stage as greyed out, and Case Progress was calculated without counting the skipped stage.

In short: the Condition Action successfully wrote the correct state to the database, but the later stage-completion save overwrote it with stale in-memory data.