### PR TITLE
feat: support Client Credentials token access across all API layers

### DIFF
--- a/packages/flowFlex-backend/Application/Services/OW/Permission/PermissionHelpers.cs
+++ b/packages/flowFlex-backend/Application/Services/OW/Permission/PermissionHelpers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FlowFlex.Domain.Shared;
+using FlowFlex.Domain.Shared.Const;
 using FlowFlex.Domain.Shared.Helpers;
 using FlowFlex.Domain.Shared.Models;
 using Microsoft.AspNetCore.Http;
@@ -269,6 +270,14 @@ namespace FlowFlex.Application.Services.OW.Permission
         public virtual bool HasAdminPrivileges()
         {
             return IsSystemAdmin() || IsTenantAdmin();
+        }
+
+        /// <summary>
+        /// Check if current request is using a Client Credentials token (service-to-service communication)
+        /// </summary>
+        public bool IsClientCredentialsToken()
+        {
+            return _userContext?.Schema == AuthSchemes.ItemIamClientIdentification;
         }
 
         #endregion

--- a/packages/flowFlex-backend/Application/Services/OW/PermissionService.cs
+++ b/packages/flowFlex-backend/Application/Services/OW/PermissionService.cs
@@ -212,6 +212,13 @@ namespace FlowFlex.Application.Services.OW
                     return PermissionResult.CreateSuccess(true, true, "TenantAdmin");
                 }
 
+                // Step 0b: Client Credentials token bypass (service-to-service communication)
+                if (_helpers.IsClientCredentialsToken())
+                {
+                    _logger.LogInformation("Client Credentials token detected, bypassing all permission checks for workflow {WorkflowId}", workflowId);
+                    return PermissionResult.CreateSuccess(true, true, "ClientCredentials");
+                }
+
                 // Step 1: Validate input
                 if (userId <= 0 || workflowId <= 0)
                 {
@@ -364,6 +371,13 @@ namespace FlowFlex.Application.Services.OW
                 {
                     _logger.LogInformation("User {UserId} is Tenant Admin, bypassing all permission checks", userId);
                     return PermissionResult.CreateSuccess(true, true, "TenantAdmin");
+                }
+
+                // Step 0b: Client Credentials token bypass (service-to-service communication)
+                if (_helpers.IsClientCredentialsToken())
+                {
+                    _logger.LogInformation("Client Credentials token detected, bypassing all permission checks for stage {StageId}", stageId);
+                    return PermissionResult.CreateSuccess(true, true, "ClientCredentials");
                 }
 
                 // Step 0.1: Portal token bypass for [PortalAccess] endpoints
@@ -560,6 +574,13 @@ namespace FlowFlex.Application.Services.OW
                 {
                     _logger.LogInformation("User {UserId} is Tenant Admin, bypassing all permission checks", userId);
                     return PermissionResult.CreateSuccess(true, true, "TenantAdmin");
+                }
+
+                // Step 0b: Client Credentials token bypass (service-to-service communication)
+                if (_helpers.IsClientCredentialsToken())
+                {
+                    _logger.LogInformation("Client Credentials token detected, bypassing all permission checks for case {CaseId}", caseId);
+                    return PermissionResult.CreateSuccess(true, true, "ClientCredentials");
                 }
 
                 // Step 0.1: Portal token bypass for [PortalAccess] endpoints

--- a/packages/flowFlex-backend/Application/Services/OW/StageCondition/StageConditionService.cs
+++ b/packages/flowFlex-backend/Application/Services/OW/StageCondition/StageConditionService.cs
@@ -991,6 +991,12 @@ namespace FlowFlex.Application.Services.OW
         /// </summary>
         private async Task ValidateWorkflowPermissionAsync(long workflowId, OperationTypeEnum operationType)
         {
+            // Client Credentials token bypass - service-to-service communication has full access
+            if (_userContext?.Schema == Domain.Shared.Const.AuthSchemes.ItemIamClientIdentification)
+            {
+                return;
+            }
+
             if (string.IsNullOrEmpty(_userContext?.UserId) || !long.TryParse(_userContext.UserId, out var userId))
             {
                 throw new CRMException(ErrorCodeEnum.AuthenticationFail, "User not authenticated");

--- a/packages/flowFlex-backend/Application/Services/OW/StageService.cs
+++ b/packages/flowFlex-backend/Application/Services/OW/StageService.cs
@@ -113,25 +113,29 @@ namespace FlowFlex.Application.Services.OW
             }
 
             // Check Workflow permission before creating stage
-            var userId = _userContext?.UserId;
-            if (string.IsNullOrEmpty(userId) || !long.TryParse(userId, out var userIdLong))
+            // Client Credentials token bypass - service-to-service communication has full access
+            if (_userContext?.Schema != Domain.Shared.Const.AuthSchemes.ItemIamClientIdentification)
             {
-                throw new CRMException(ErrorCodeEnum.AuthenticationFail, "User not authenticated");
+                var userId = _userContext?.UserId;
+                if (string.IsNullOrEmpty(userId) || !long.TryParse(userId, out var userIdLong))
+                {
+                    throw new CRMException(ErrorCodeEnum.AuthenticationFail, "User not authenticated");
+                }
+
+                var workflowPermission = await _permissionService.CheckWorkflowAccessAsync(
+                    userIdLong,
+                    input.WorkflowId,
+                    Domain.Shared.Enums.Permission.OperationTypeEnum.Operate);
+
+                if (!workflowPermission.Success || !workflowPermission.CanOperate)
+                {
+                    throw new CRMException(ErrorCodeEnum.BusinessError,
+                        $"No permission to create stage in workflow '{workflow.Name}': {workflowPermission.ErrorMessage}");
+                }
+
+                _logger.LogInformation("User {UserId} has permission to create stage in workflow {WorkflowId} ({WorkflowName})",
+                    userIdLong, input.WorkflowId, workflow.Name);
             }
-
-            var workflowPermission = await _permissionService.CheckWorkflowAccessAsync(
-                userIdLong,
-                input.WorkflowId,
-                Domain.Shared.Enums.Permission.OperationTypeEnum.Operate);
-
-            if (!workflowPermission.Success || !workflowPermission.CanOperate)
-            {
-                throw new CRMException(ErrorCodeEnum.BusinessError,
-                    $"No permission to create stage in workflow '{workflow.Name}': {workflowPermission.ErrorMessage}");
-            }
-
-            _logger.LogInformation("User {UserId} has permission to create stage in workflow {WorkflowId} ({WorkflowName})",
-                userIdLong, input.WorkflowId, workflow.Name);
 
             // Validate team IDs in ViewTeams and OperateTeams
             await ValidateTeamSelectionsAsync(input.ViewTeams, input.OperateTeams);
@@ -288,25 +292,29 @@ namespace FlowFlex.Application.Services.OW
             }
 
             // Check Workflow permission before updating stage
-            var userId = _userContext?.UserId;
-            if (string.IsNullOrEmpty(userId) || !long.TryParse(userId, out var userIdLong))
+            // Client Credentials token bypass - service-to-service communication has full access
+            if (_userContext?.Schema != Domain.Shared.Const.AuthSchemes.ItemIamClientIdentification)
             {
-                throw new CRMException(ErrorCodeEnum.AuthenticationFail, "User not authenticated");
+                var userId = _userContext?.UserId;
+                if (string.IsNullOrEmpty(userId) || !long.TryParse(userId, out var userIdLong))
+                {
+                    throw new CRMException(ErrorCodeEnum.AuthenticationFail, "User not authenticated");
+                }
+
+                var workflowPermission = await _permissionService.CheckWorkflowAccessAsync(
+                    userIdLong,
+                    stage.WorkflowId,
+                    Domain.Shared.Enums.Permission.OperationTypeEnum.Operate);
+
+                if (!workflowPermission.Success || !workflowPermission.CanOperate)
+                {
+                    throw new CRMException(ErrorCodeEnum.BusinessError,
+                        $"No permission to update stage '{stage.Name}' in workflow '{workflow.Name}': {workflowPermission.ErrorMessage}");
+                }
+
+                _logger.LogInformation("User {UserId} has permission to update stage {StageId} ({StageName}) in workflow {WorkflowId} ({WorkflowName})",
+                    userIdLong, id, stage.Name, stage.WorkflowId, workflow.Name);
             }
-
-            var workflowPermission = await _permissionService.CheckWorkflowAccessAsync(
-                userIdLong,
-                stage.WorkflowId,
-                Domain.Shared.Enums.Permission.OperationTypeEnum.Operate);
-
-            if (!workflowPermission.Success || !workflowPermission.CanOperate)
-            {
-                throw new CRMException(ErrorCodeEnum.BusinessError,
-                    $"No permission to update stage '{stage.Name}' in workflow '{workflow.Name}': {workflowPermission.ErrorMessage}");
-            }
-
-            _logger.LogInformation("User {UserId} has permission to update stage {StageId} ({StageName}) in workflow {WorkflowId} ({WorkflowName})",
-                userIdLong, id, stage.Name, stage.WorkflowId, workflow.Name);
 
             // Validate team IDs in ViewTeams and OperateTeams (only when provided)
             await ValidateTeamSelectionsAsync(input.ViewTeams, input.OperateTeams);
@@ -762,6 +770,24 @@ namespace FlowFlex.Application.Services.OW
             var userIdString = _userContext?.UserId;
             if (string.IsNullOrEmpty(userIdString) || !long.TryParse(userIdString, out var userId) || userId <= 0)
             {
+                // Client Credentials token bypass - return all stages without permission checks
+                if (_userContext?.Schema == Domain.Shared.Const.AuthSchemes.ItemIamClientIdentification)
+                {
+                    _logger.LogDebug(
+                        "Client Credentials token detected, skipping permission filtering for workflow {WorkflowId} stages",
+                        workflowId);
+                    var clientResult = _mapper.Map<List<StageOutputDto>>(list);
+                    foreach (var stageDto in clientResult)
+                    {
+                        stageDto.Permission = new PermissionInfoDto
+                        {
+                            CanView = true,
+                            CanOperate = true
+                        };
+                    }
+                    return clientResult;
+                }
+
                 _logger.LogWarning("User ID is invalid, returning empty stage list");
                 return new List<StageOutputDto>();
             }
@@ -1246,10 +1272,15 @@ namespace FlowFlex.Application.Services.OW
             }
 
             // Check permission
-            var userId = _userContext?.UserId;
-            if (string.IsNullOrEmpty(userId) || !long.TryParse(userId, out var userIdLong))
+            // Client Credentials token bypass - service-to-service communication has full access
+            long userIdLong = 0;
+            if (_userContext?.Schema != Domain.Shared.Const.AuthSchemes.ItemIamClientIdentification)
             {
-                throw new CRMException(ErrorCodeEnum.AuthenticationFail, "User not authenticated");
+                var userId = _userContext?.UserId;
+                if (string.IsNullOrEmpty(userId) || !long.TryParse(userId, out userIdLong))
+                {
+                    throw new CRMException(ErrorCodeEnum.AuthenticationFail, "User not authenticated");
+                }
             }
 
             // Check if stage condition exists

--- a/packages/flowFlex-backend/Application/Services/OW/UserService.cs
+++ b/packages/flowFlex-backend/Application/Services/OW/UserService.cs
@@ -19,6 +19,7 @@ using BC = BCrypt.Net.BCrypt;
 using FlowFlex.Application.Services.OW.Extensions;
 using FlowFlex.Domain;
 using FlowFlex.Domain.Shared;
+using FlowFlex.Domain.Shared.Const;
 using FlowFlex.Domain.Shared.Models;
 
 namespace FlowFlex.Application.Services.OW
@@ -498,6 +499,13 @@ namespace FlowFlex.Application.Services.OW
         /// <returns>User DTO</returns>
         public async Task<UserDto> GetCurrentUserAsync()
         {
+            // Client Credentials token - no "current user" concept
+            var userContext = _httpContextAccessor.HttpContext?.RequestServices?.GetService<UserContext>();
+            if (userContext?.Schema == FlowFlex.Domain.Shared.Const.AuthSchemes.ItemIamClientIdentification)
+            {
+                throw new CRMException(ErrorCodeEnum.BusinessError, "Client Credentials token does not have a user profile");
+            }
+
             // Get user ID from user context
             var userId = _userContextService.GetCurrentUserId();
             if (userId <= 0)
@@ -532,6 +540,13 @@ namespace FlowFlex.Application.Services.OW
         /// <returns>Whether change was successful</returns>
         public async Task<bool> ChangePasswordAsync(ChangePasswordRequestDto request)
         {
+            // Client Credentials token - cannot change password
+            var userContext = _httpContextAccessor.HttpContext?.RequestServices?.GetService<UserContext>();
+            if (userContext?.Schema == FlowFlex.Domain.Shared.Const.AuthSchemes.ItemIamClientIdentification)
+            {
+                throw new CRMException(ErrorCodeEnum.BusinessError, "Client Credentials token cannot change password");
+            }
+
             // Get current user ID
             var userId = _userContextService.GetCurrentUserId();
             if (userId <= 0)

--- a/packages/flowFlex-backend/WebApi/Authentication/TokenValidatedHandler.cs
+++ b/packages/flowFlex-backend/WebApi/Authentication/TokenValidatedHandler.cs
@@ -292,26 +292,30 @@ namespace WebApi.Authentication
          HttpContext httpContext,
          List<Claim> claims)
         {
+            // Set TenantId from X-Tenant-Id header if present
             if (httpContext.Request.Headers.TryGetValue("X-Tenant-Id", out StringValues tenantId))
             {
                 userContext.TenantId = tenantId;
                 userContext.CompanyId = tenantId;
-                userContext.UserId = "0";
-                userContext.UserName = "";
-                if (claims.Count != 0)
+            }
+
+            userContext.UserId = "0";
+
+            // Always set UserName from client_name claim (fallback to client_id)
+            userContext.UserName = "";
+            if (claims.Count != 0)
+            {
+                var clientNameClaim = claims.FirstOrDefault(x => x.Type == CustomClaimTypes.ClientName);
+                if (clientNameClaim != null)
                 {
-                    var scope = claims.FirstOrDefault(x => x.Type == CustomClaimTypes.ClientName);
-                    if (scope != null)
+                    userContext.UserName = clientNameClaim.Value;
+                }
+                if (string.IsNullOrEmpty(userContext.UserName))
+                {
+                    var clientIdClaim = claims.FirstOrDefault(x => x.Type == CustomClaimTypes.ClientId);
+                    if (clientIdClaim != null)
                     {
-                        userContext.UserName += $"{scope.Value}";
-                    }
-                    if (string.IsNullOrEmpty(userContext.UserName))
-                    {
-                        scope = claims.FirstOrDefault(x => x.Type == CustomClaimTypes.ClientId);
-                        if (scope != null)
-                        {
-                            userContext.UserName += $"{scope.Value}";
-                        }
+                        userContext.UserName = clientIdClaim.Value;
                     }
                 }
             }

--- a/packages/flowFlex-backend/WebApi/Controllers/ControllerBase.cs
+++ b/packages/flowFlex-backend/WebApi/Controllers/ControllerBase.cs
@@ -41,6 +41,13 @@ public abstract class ControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     /// <exception cref="UnauthorizedAccessException">Thrown when user ID cannot be resolved from headers or JWT</exception>
     protected long GetCurrentUserId()
     {
+        // Client Credentials token bypass - return 0 for service-to-service communication
+        var userContext = HttpContext.RequestServices.GetService<FlowFlex.Domain.Shared.Models.UserContext>();
+        if (userContext?.Schema == FlowFlex.Domain.Shared.Const.AuthSchemes.ItemIamClientIdentification)
+        {
+            return 0;
+        }
+
         // Get user ID from request header
         var userIdHeader = HttpContext.Request.Headers["X-User-Id"].FirstOrDefault();
 

--- a/packages/flowFlex-backend/WebApi/Filters/RequirePermissionAttribute.cs
+++ b/packages/flowFlex-backend/WebApi/Filters/RequirePermissionAttribute.cs
@@ -55,6 +55,14 @@ namespace FlowFlex.WebApi.Filters
                     return;
                 }
 
+                // Fast path: Client Credentials token bypasses permission check (service-to-service communication)
+                if (userContext?.Schema == AuthSchemes.ItemIamClientIdentification)
+                {
+                    logger.LogInformation("Client Credentials token detected - bypassing RequirePermission check");
+                    await next();
+                    return;
+                }
+
                 // Step 1: Get entity ID from route parameters
                 if (!context.ActionArguments.TryGetValue(_entityIdParameterName, out var entityIdObj))
                 {


### PR DESCRIPTION
- Add client token bypass in RequirePermissionAttribute (Action Filter)
- Add client token bypass in PermissionService (Workflow/Stage/Case)
- Add client token bypass in StageService (Create/Update/Complete/GetList)
- Add client token bypass in StageConditionService (ValidateWorkflowPermission)
- Add client token bypass in ControllerBase.GetCurrentUserId()
- Add client token guard in UserService (GetCurrentUser/ChangePassword)
- Add IsClientCredentialsToken() to PermissionHelpers
- Fix TokenValidatedHandler.SetTenantIdAndUserName to always set UserName from client_name claim regardless of X-Tenant-Id header presence