### PR TITLE
Explicitly set "Started" as the correct initial status for a newly cr…

### DIFF
--- a/packages/flowFlex-backend/Application/Services/OW/OnboardingServices/OnboardingCrudService.cs
+++ b/packages/flowFlex-backend/Application/Services/OW/OnboardingServices/OnboardingCrudService.cs
@@ -623,8 +623,9 @@ namespace FlowFlex.Application.Services.OW.OnboardingServices
             entity.CurrentStageOrder = firstStage?.Order ?? 0;
             // OW-691 fix: Status is Ignored in AutoMapper (to protect Edit Case from overwriting it),
             // so entity.Status is always the C# default "Inactive" here regardless of input.
-            // Explicitly set the correct initial status for a newly created case.
-            entity.Status = OnboardingStatusEnum.Started.ToDbString();
+            // Explicitly set "Started" as the correct initial status for a newly created case.
+            // Note: "Started" is the historical initial value used throughout the system (not in OnboardingStatusEnum).
+            entity.Status = "Started";
             entity.StartDate = entity.StartDate ?? DateTimeOffset.UtcNow;
             entity.CurrentStageStartTime = null;
             entity.CompletionRate = 0;


### PR DESCRIPTION
…eated case.